### PR TITLE
Fix incorrect NDC version in capabilities

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ import {
 } from "@hasura/ndc-sdk-typescript";
 
 export const CAPABILITIES_RESPONSE: CapabilitiesResponse = {
-  version: "^0.1.0",
+  version: "0.1.2",
   capabilities: {
     query: {
       aggregates: null,


### PR DESCRIPTION
The version being returned from the capabilities endpoint is invalid. It currently returns a semver _range_, which violates the NDC Spec; it should return the [semver version number of the NDC spec that the connector speaks](https://hasura.github.io/ndc-spec/specification/capabilities.html#response-fields). 

Since this connector uses the NDC TypeScript SDK v4.4.0, [that means it speaks NDC Spec v0.1.2](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.4.0). The capabilities response has been updated to reflect that.

The current version of the Hasura engine will accept the incorrect version, but future versions of the Hasura engine will eventually reject incorrect version numbers, so fixing it is a good thing. 🙂